### PR TITLE
Update wsl_instructions.md

### DIFF
--- a/wsl_instructions.md
+++ b/wsl_instructions.md
@@ -24,7 +24,7 @@ sudo apt-get install \
   libglu1-mesa-dev \
   libgtk2.0-0 \
   libxxf86vm1 \
-  mesa-common-dev
+  mesa-common-dev \
   mesa-utils \
   openssl \
   x11-apps


### PR DESCRIPTION
Typo in WSL install instructions leads to missing dependencies - fixed by adding missing backslash.